### PR TITLE
Fix asserion failed when restoring context

### DIFF
--- a/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.m
+++ b/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.m
@@ -84,6 +84,7 @@
         CGContextSetAlpha(context, self.opacity.floatValue);
     }
     if (self.gradient) {
+        CGContextSaveGState(context);
         CGContextAddPath(context, self.path.CGPath);
         CGContextClip(context);
         [self.gradient drawInContext:context];


### PR DESCRIPTION
You forgot save GState before restore it in next lines.
Fix crash: Assertion failed: (s->stack->next != NULL), function CGGStackRestore, file Context/CGGStack.c, line 77.
