### PR TITLE
Add support for stroke-width

### DIFF
--- a/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.h
+++ b/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.h
@@ -21,6 +21,7 @@
 + (instancetype)styledPathWithPath:(UIBezierPath *)path
                          fillColor:(UIColor *)fillColor
                        strokeColor:(UIColor *)strokeColor
+                        strokeWidth:(CGFloat)strokeWidth
                           gradient:(JAMSVGGradient *)gradient
                   affineTransforms:(NSArray *)transforms
                            opacity:(NSNumber *)opacity;

--- a/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.m
+++ b/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPath.m
@@ -20,6 +20,7 @@
 @property (nonatomic) JAMSVGGradient *gradient;
 @property (nonatomic) NSArray *affineTransforms;
 @property (nonatomic) NSNumber *opacity;
+@property (nonatomic) CGFloat strokeWidth;
 @end
 
 @implementation JAMStyledBezierPath
@@ -56,6 +57,7 @@
 + (instancetype)styledPathWithPath:(UIBezierPath *)path
                          fillColor:(UIColor *)fillColor
                        strokeColor:(UIColor *)strokeColor
+                        strokeWidth:(CGFloat)strokeWidth
                           gradient:(JAMSVGGradient *)gradient
                   affineTransforms:(NSArray *)transforms
                            opacity:(NSNumber *)opacity;
@@ -68,6 +70,7 @@
     styledPath.gradient = gradient;
     styledPath.affineTransforms = transforms;
     styledPath.opacity = opacity;
+    styledPath.strokeWidth = strokeWidth;
     
     return styledPath;
 }
@@ -94,6 +97,9 @@
         CGContextFillPath(context);
     }
     if (self.strokeColor && self.path.lineWidth > 0.f) {
+        if (self.strokeWidth) {
+          CGContextSetLineWidth(context, self.strokeWidth);
+        }
         CGContextSetStrokeColorWithColor(context, self.strokeColor.CGColor);
         CGContextAddPath(context, self.path.CGPath);
         CGContextStrokePath(context);

--- a/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPathFactory.m
+++ b/Classes/JAMSVGImage/Path and Parser/JAMStyledBezierPathFactory.m
@@ -21,6 +21,7 @@
 @property (nonatomic) UIBezierPath *path;
 @property (nonatomic) UIColor *fillColor;
 @property (nonatomic) UIColor *strokeColor;
+@property (nonatomic) CGFloat strokeWidth;
 @property (nonatomic) JAMSVGGradient *gradient;
 @property (nonatomic) NSValue *transform;
 @property (nonatomic) NSNumber *opacity;
@@ -323,10 +324,12 @@
     NSString *strokeColorStringValue = self.webColors[strokeColorString];
     UIColor *fillColor = fillColorStringValue ? [UIColor colorFromString:fillColorStringValue] : [attributes fillColorForKey:@"fill"];
     UIColor *strokeColor = strokeColorStringValue ? [UIColor colorFromString:strokeColorStringValue] : [attributes strokeColorForKey:@"stroke"];
+    CGFloat strokeWidth = [attributes strokeWeightForKey:@"stroke-width"];
     
     return [JAMStyledBezierPath styledPathWithPath:[self applyStrokeAttributes:attributes toPath:path]
                                          fillColor:fillColor
                                        strokeColor:strokeColor
+                                        strokeWidth: strokeWidth
                                           gradient:[self gradientForFillURL:attributes[@"fill"]]
                                   affineTransforms:transforms
                                            opacity:[self opacityFromAttributes:attributes]];


### PR DESCRIPTION
Without this patch, a bezier path's line width would always be 1.0 and not the corresponding stroke-width.  https://github.com/albertstartup/JAMSVGImage/tree/stroke-width-bug demonstrates this.
Let me know if anything is missing.
