### PR TITLE
Simplified Carthage support (iOS & tvOS) + Option to opt-out of caching

### DIFF
--- a/Classes/JAMSVGImage/SVG Image/JAMSVGImage.h
+++ b/Classes/JAMSVGImage/SVG Image/JAMSVGImage.h
@@ -21,6 +21,9 @@
 /** Scale at which the SVG image will be drawn. Default is 1.0. */
 @property (nonatomic) CGFloat scale;
 
+/** Allows setting the caching behavior. Defaults to true. */
+@property (class, nonatomic, assign) BOOL isCachingEnabled;
+
 /** Returns a CGImageRef or UIImage of the SVG image at the current scale. */
 - (CGImageRef)CGImage;
 - (UIImage *)image;

--- a/Classes/JAMSVGImage/SVG Image/JAMSVGImage.h
+++ b/Classes/JAMSVGImage/SVG Image/JAMSVGImage.h
@@ -22,7 +22,8 @@
 @property (nonatomic) CGFloat scale;
 
 /** Allows setting the caching behavior. Defaults to true. */
-@property (class, nonatomic, assign) BOOL isCachingEnabled;
++ (BOOL)isCachingEnabled;
++ (void)setIsCachingEnabled:(BOOL)isCachingEnabled;
 
 /** Returns a CGImageRef or UIImage of the SVG image at the current scale. */
 - (CGImageRef)CGImage;

--- a/Classes/JAMSVGImage/SVG Image/JAMSVGImage.m
+++ b/Classes/JAMSVGImage/SVG Image/JAMSVGImage.m
@@ -196,11 +196,11 @@ static NSCache *imageCache = nil;
     return image;
 }
 
-- (BOOL)isCachingEnabled {
++ (BOOL)isCachingEnabled {
     return _isCachingEnabled;
 }
 
-- (void)setIsCachingEnabled:(BOOL)isCachingEnabled {
++ (void)setIsCachingEnabled:(BOOL)isCachingEnabled {
     if (imageCache && !isCachingEnabled) {
         [imageCache removeAllObjects];
     }

--- a/Classes/JAMSVGImage/SVG Image/JAMSVGImage.m
+++ b/Classes/JAMSVGImage/SVG Image/JAMSVGImage.m
@@ -22,6 +22,7 @@
 
 @implementation JAMSVGImage
 
+static BOOL _isCachingEnabled = YES; // caching is enabled by default
 static NSCache *imageCache = nil;
 
 #pragma mark - NSCoding Methods
@@ -70,13 +71,19 @@ static NSCache *imageCache = nil;
     if (!fileName) {
         fileName = [bundle pathForResource:name ofType:@"svgz"];
     }
-    
-    JAMSVGImage *image = [imageCache objectForKey:fileName];
-    if (!image) {
+
+    JAMSVGImage *image;
+
+    if (_isCachingEnabled) {
+        image = [imageCache objectForKey:fileName];
+        if (!image) {
+            image = [JAMSVGImage imageWithContentsOfFile:fileName];
+            [imageCache setObject:image forKey:fileName];
+        }
+    } else {
         image = [JAMSVGImage imageWithContentsOfFile:fileName];
-        [imageCache setObject:image forKey:fileName];
     }
-    
+
     return image;
 }
 
@@ -187,6 +194,17 @@ static NSCache *imageCache = nil;
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return image;
+}
+
+- (BOOL)isCachingEnabled {
+    return _isCachingEnabled;
+}
+
+- (void)setIsCachingEnabled:(BOOL)isCachingEnabled {
+    if (imageCache && !isCachingEnabled) {
+        [imageCache removeAllObjects];
+    }
+    _isCachingEnabled = isCachingEnabled;
 }
 
 @end

--- a/Classes/JAMSVGImage/Supporting Files/Info.plist
+++ b/Classes/JAMSVGImage/Supporting Files/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.6</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Classes/JAMSVGImage/Supporting Files/JAMSVGImage-Umbrella.h
+++ b/Classes/JAMSVGImage/Supporting Files/JAMSVGImage-Umbrella.h
@@ -1,0 +1,25 @@
+//
+//  JAMSVGImage-Umbrella.h
+//  JAMSVGImage
+//
+//  Created by Cihat Gündüz on 11.01.17.
+//  Copyright © 2017 Jeff Menter. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for JAMSVGImage iOS.
+FOUNDATION_EXPORT double JAMSVGImage_VersionNumber;
+
+//! Project version string for JAMSVGImage iOS.
+FOUNDATION_EXPORT const unsigned char JAMSVGImage_VersionString[];
+
+#import <JAMSVGImage/JAMSVGImage.h>
+#import <JAMSVGImage/UIImage+SVG.h>
+#import <JAMSVGImage/JAMSVGImageView.h>
+#import <JAMSVGImage/JAMSVGButton.h>
+#import <JAMSVGImage/JAMStyledBezierPath.h>
+#import <JAMSVGImage/JAMSVGParser.h>
+#import <JAMSVGImage/JAMStyledBezierPathFactory.h>
+#import <JAMSVGImage/JAMSVGGradientParts.h>
+#import <JAMSVGImage/JAMSVGUtilities.h>

--- a/Classes/JAMSVGImage/Supporting Files/module.modulemap
+++ b/Classes/JAMSVGImage/Supporting Files/module.modulemap
@@ -1,0 +1,6 @@
+framework module JAMSVGImage {
+    umbrella header "JAMSVGImage-Umbrella.h"
+
+    export *
+    module * { export * }
+}

--- a/JAMSVGImage.xcodeproj/project.pbxproj
+++ b/JAMSVGImage.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		8225C32E1E263A9A00229F51 /* UIImage+SVG.m in Sources */ = {isa = PBXBuildFile; fileRef = 630A5D2F1A637DA90051D2D5 /* UIImage+SVG.m */; };
 		8225C3371E263AEE00229F51 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 630E28AF1A44CB1E0001106F /* libz.dylib */; };
 		8225C3381E263AEE00229F51 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 630E28AF1A44CB1E0001106F /* libz.dylib */; };
+		8225C33B1E263EFD00229F51 /* JAMSVGImage-Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C33C1E263EFE00229F51 /* JAMSVGImage-Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB5881E019D5CE2900797A2E /* Launch.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB5881DF19D5CE2900797A2E /* Launch.xib */; };
 /* End PBXBuildFile section */
 
@@ -144,6 +146,8 @@
 		8225C2FF1E26391C00229F51 /* JAMSVGImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JAMSVGImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8225C3111E26392800229F51 /* JAMSVGImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JAMSVGImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8225C31C1E263A0B00229F51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JAMSVGImage-Umbrella.h"; sourceTree = "<group>"; };
+		8225C33A1E263D5700229F51 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		EB5881DF19D5CE2900797A2E /* Launch.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = Launch.xib; path = ../Launch.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -374,6 +378,8 @@
 			isa = PBXGroup;
 			children = (
 				8225C31C1E263A0B00229F51 /* Info.plist */,
+				8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */,
+				8225C33A1E263D5700229F51 /* module.modulemap */,
 			);
 			path = "Supporting Files";
 			sourceTree = "<group>";
@@ -385,6 +391,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8225C33B1E263EFD00229F51 /* JAMSVGImage-Umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,6 +399,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8225C33C1E263EFE00229F51 /* JAMSVGImage-Umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -741,6 +749,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
 				PRODUCT_NAME = JAMSVGImage;
@@ -775,6 +784,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
 				PRODUCT_NAME = JAMSVGImage;
@@ -808,6 +818,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
 				PRODUCT_NAME = JAMSVGImage;
@@ -845,6 +856,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
 				PRODUCT_NAME = JAMSVGImage;
@@ -887,6 +899,7 @@
 				8225C30A1E26391C00229F51 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8225C3161E26392800229F51 /* Build configuration list for PBXNativeTarget "JAMSVGImage-tvOS" */ = {
 			isa = XCConfigurationList;
@@ -895,6 +908,7 @@
 				8225C3181E26392800229F51 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/JAMSVGImage.xcodeproj/project.pbxproj
+++ b/JAMSVGImage.xcodeproj/project.pbxproj
@@ -55,6 +55,26 @@
 		63D2068318EF501F00FAC851 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D2068218EF501F00FAC851 /* main.m */; };
 		63D2068718EF501F00FAC851 /* JAMAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D2068618EF501F00FAC851 /* JAMAppDelegate.m */; };
 		63D2069218EF501F00FAC851 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63D2069118EF501F00FAC851 /* Images.xcassets */; };
+		8225C31D1E263A8700229F51 /* JAMSVGUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CA8DFB1A426F870095ECF3 /* JAMSVGUtilities.m */; };
+		8225C31E1E263A8700229F51 /* JAMSVGUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CA8DFB1A426F870095ECF3 /* JAMSVGUtilities.m */; };
+		8225C31F1E263A9100229F51 /* JAMStyledBezierPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B2D18EF512F00AE444E /* JAMStyledBezierPath.m */; };
+		8225C3201E263A9100229F51 /* JAMSVGParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3318EF512F00AE444E /* JAMSVGParser.m */; };
+		8225C3211E263A9100229F51 /* JAMStyledBezierPathFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B2F18EF512F00AE444E /* JAMStyledBezierPathFactory.m */; };
+		8225C3221E263A9100229F51 /* JAMSVGGradientParts.m in Sources */ = {isa = PBXBuildFile; fileRef = 638E660618F39529007A2EAA /* JAMSVGGradientParts.m */; };
+		8225C3231E263A9100229F51 /* JAMStyledBezierPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B2D18EF512F00AE444E /* JAMStyledBezierPath.m */; };
+		8225C3241E263A9100229F51 /* JAMSVGParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3318EF512F00AE444E /* JAMSVGParser.m */; };
+		8225C3251E263A9100229F51 /* JAMStyledBezierPathFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B2F18EF512F00AE444E /* JAMStyledBezierPathFactory.m */; };
+		8225C3261E263A9100229F51 /* JAMSVGGradientParts.m in Sources */ = {isa = PBXBuildFile; fileRef = 638E660618F39529007A2EAA /* JAMSVGGradientParts.m */; };
+		8225C3271E263A9500229F51 /* JAMSVGImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3918EF67A300AE444E /* JAMSVGImageView.m */; };
+		8225C3281E263A9500229F51 /* JAMSVGButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 632459461A461EB200C64553 /* JAMSVGButton.m */; };
+		8225C3291E263A9500229F51 /* JAMSVGImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3918EF67A300AE444E /* JAMSVGImageView.m */; };
+		8225C32A1E263A9500229F51 /* JAMSVGButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 632459461A461EB200C64553 /* JAMSVGButton.m */; };
+		8225C32B1E263A9900229F51 /* JAMSVGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3118EF512F00AE444E /* JAMSVGImage.m */; };
+		8225C32C1E263A9900229F51 /* UIImage+SVG.m in Sources */ = {isa = PBXBuildFile; fileRef = 630A5D2F1A637DA90051D2D5 /* UIImage+SVG.m */; };
+		8225C32D1E263A9A00229F51 /* JAMSVGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A36B3118EF512F00AE444E /* JAMSVGImage.m */; };
+		8225C32E1E263A9A00229F51 /* UIImage+SVG.m in Sources */ = {isa = PBXBuildFile; fileRef = 630A5D2F1A637DA90051D2D5 /* UIImage+SVG.m */; };
+		8225C3371E263AEE00229F51 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 630E28AF1A44CB1E0001106F /* libz.dylib */; };
+		8225C3381E263AEE00229F51 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 630E28AF1A44CB1E0001106F /* libz.dylib */; };
 		EB5881E019D5CE2900797A2E /* Launch.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB5881DF19D5CE2900797A2E /* Launch.xib */; };
 /* End PBXBuildFile section */
 
@@ -121,6 +141,9 @@
 		63D2068518EF501F00FAC851 /* JAMAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JAMAppDelegate.h; sourceTree = "<group>"; };
 		63D2068618EF501F00FAC851 /* JAMAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JAMAppDelegate.m; sourceTree = "<group>"; };
 		63D2069118EF501F00FAC851 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		8225C2FF1E26391C00229F51 /* JAMSVGImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JAMSVGImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8225C3111E26392800229F51 /* JAMSVGImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JAMSVGImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8225C31C1E263A0B00229F51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EB5881DF19D5CE2900797A2E /* Launch.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = Launch.xib; path = ../Launch.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -133,6 +156,22 @@
 				63D2067918EF501F00FAC851 /* CoreGraphics.framework in Frameworks */,
 				63D2067B18EF501F00FAC851 /* UIKit.framework in Frameworks */,
 				63D2067718EF501F00FAC851 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C2FB1E26391C00229F51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8225C3371E263AEE00229F51 /* libz.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C30D1E26392800229F51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8225C3381E263AEE00229F51 /* libz.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,6 +231,7 @@
 				63F145241A477BB3008C27E4 /* UI and View */,
 				63F145251A477BDA008C27E4 /* Path and Parser */,
 				63F145261A477BEB008C27E4 /* Utilities */,
+				8225C31B1E263A0B00229F51 /* Supporting Files */,
 			);
 			path = JAMSVGImage;
 			sourceTree = "<group>";
@@ -236,6 +276,8 @@
 			isa = PBXGroup;
 			children = (
 				63D2067318EF501F00FAC851 /* JAMSVGImage.app */,
+				8225C2FF1E26391C00229F51 /* JAMSVGImage.framework */,
+				8225C3111E26392800229F51 /* JAMSVGImage.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -328,7 +370,32 @@
 			name = Utilities;
 			sourceTree = "<group>";
 		};
+		8225C31B1E263A0B00229F51 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				8225C31C1E263A0B00229F51 /* Info.plist */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		8225C2FC1E26391C00229F51 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C30E1E26392800229F51 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		63D2067218EF501F00FAC851 /* JAMSVGImage */ = {
@@ -348,6 +415,42 @@
 			productReference = 63D2067318EF501F00FAC851 /* JAMSVGImage.app */;
 			productType = "com.apple.product-type.application";
 		};
+		8225C2FE1E26391C00229F51 /* JAMSVGImage-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8225C3081E26391C00229F51 /* Build configuration list for PBXNativeTarget "JAMSVGImage-iOS" */;
+			buildPhases = (
+				8225C2FA1E26391C00229F51 /* Sources */,
+				8225C2FB1E26391C00229F51 /* Frameworks */,
+				8225C2FC1E26391C00229F51 /* Headers */,
+				8225C2FD1E26391C00229F51 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "JAMSVGImage-iOS";
+			productName = "JAMSVGImage iOS";
+			productReference = 8225C2FF1E26391C00229F51 /* JAMSVGImage.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8225C3101E26392800229F51 /* JAMSVGImage-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8225C3161E26392800229F51 /* Build configuration list for PBXNativeTarget "JAMSVGImage-tvOS" */;
+			buildPhases = (
+				8225C30C1E26392800229F51 /* Sources */,
+				8225C30D1E26392800229F51 /* Frameworks */,
+				8225C30E1E26392800229F51 /* Headers */,
+				8225C30F1E26392800229F51 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "JAMSVGImage-tvOS";
+			productName = "JAMSVGImage-tvOS";
+			productReference = 8225C3111E26392800229F51 /* JAMSVGImage.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -357,6 +460,16 @@
 				CLASSPREFIX = JAM;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Jeff Menter";
+				TargetAttributes = {
+					8225C2FE1E26391C00229F51 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+					};
+					8225C3101E26392800229F51 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = 63D2066E18EF501F00FAC851 /* Build configuration list for PBXProject "JAMSVGImage" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -372,6 +485,8 @@
 			projectRoot = "";
 			targets = (
 				63D2067218EF501F00FAC851 /* JAMSVGImage */,
+				8225C2FE1E26391C00229F51 /* JAMSVGImage-iOS */,
+				8225C3101E26392800229F51 /* JAMSVGImage-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -417,6 +532,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8225C2FD1E26391C00229F51 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C30F1E26392800229F51 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -436,6 +565,38 @@
 				638E660718F39529007A2EAA /* JAMSVGGradientParts.m in Sources */,
 				63A36B3718EF512F00AE444E /* JAMSVGParser.m in Sources */,
 				632459471A461EB200C64553 /* JAMSVGButton.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C2FA1E26391C00229F51 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8225C32E1E263A9A00229F51 /* UIImage+SVG.m in Sources */,
+				8225C31D1E263A8700229F51 /* JAMSVGUtilities.m in Sources */,
+				8225C3201E263A9100229F51 /* JAMSVGParser.m in Sources */,
+				8225C3281E263A9500229F51 /* JAMSVGButton.m in Sources */,
+				8225C32D1E263A9A00229F51 /* JAMSVGImage.m in Sources */,
+				8225C3211E263A9100229F51 /* JAMStyledBezierPathFactory.m in Sources */,
+				8225C3221E263A9100229F51 /* JAMSVGGradientParts.m in Sources */,
+				8225C3271E263A9500229F51 /* JAMSVGImageView.m in Sources */,
+				8225C31F1E263A9100229F51 /* JAMStyledBezierPath.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8225C30C1E26392800229F51 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8225C32C1E263A9900229F51 /* UIImage+SVG.m in Sources */,
+				8225C31E1E263A8700229F51 /* JAMSVGUtilities.m in Sources */,
+				8225C3241E263A9100229F51 /* JAMSVGParser.m in Sources */,
+				8225C32A1E263A9500229F51 /* JAMSVGButton.m in Sources */,
+				8225C32B1E263A9900229F51 /* JAMSVGImage.m in Sources */,
+				8225C3251E263A9100229F51 /* JAMStyledBezierPathFactory.m in Sources */,
+				8225C3261E263A9100229F51 /* JAMSVGGradientParts.m in Sources */,
+				8225C3291E263A9500229F51 /* JAMSVGImageView.m in Sources */,
+				8225C3231E263A9100229F51 /* JAMStyledBezierPath.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -536,6 +697,7 @@
 				INFOPLIST_FILE = "JAMSVGImage/JAMSVGImage-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -551,8 +713,149 @@
 				INFOPLIST_FILE = "JAMSVGImage/JAMSVGImage-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		8225C3091E26391C00229F51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
+				PRODUCT_NAME = JAMSVGImage;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8225C30A1E26391C00229F51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
+				PRODUCT_NAME = JAMSVGImage;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8225C3171E26392800229F51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
+				PRODUCT_NAME = JAMSVGImage;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8225C3181E26392800229F51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Classes/JAMSVGImage/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamitlabs.JAMSVGImage;
+				PRODUCT_NAME = JAMSVGImage;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -576,6 +879,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		8225C3081E26391C00229F51 /* Build configuration list for PBXNativeTarget "JAMSVGImage-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8225C3091E26391C00229F51 /* Debug */,
+				8225C30A1E26391C00229F51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		8225C3161E26392800229F51 /* Build configuration list for PBXNativeTarget "JAMSVGImage-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8225C3171E26392800229F51 /* Debug */,
+				8225C3181E26392800229F51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/JAMSVGImage.xcodeproj/project.pbxproj
+++ b/JAMSVGImage.xcodeproj/project.pbxproj
@@ -77,6 +77,24 @@
 		8225C3381E263AEE00229F51 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 630E28AF1A44CB1E0001106F /* libz.dylib */; };
 		8225C33B1E263EFD00229F51 /* JAMSVGImage-Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8225C33C1E263EFE00229F51 /* JAMSVGImage-Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8225C3391E263D2900229F51 /* JAMSVGImage-Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C34D1E26401B00229F51 /* JAMSVGImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3018EF512F00AE444E /* JAMSVGImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C34E1E26401B00229F51 /* UIImage+SVG.h in Headers */ = {isa = PBXBuildFile; fileRef = 630A5D2E1A637DA90051D2D5 /* UIImage+SVG.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C34F1E26401B00229F51 /* JAMSVGImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3818EF67A300AE444E /* JAMSVGImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3501E26401B00229F51 /* JAMSVGButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 632459451A461EB200C64553 /* JAMSVGButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3511E26401B00229F51 /* JAMStyledBezierPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B2C18EF512F00AE444E /* JAMStyledBezierPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3521E26401B00229F51 /* JAMSVGParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3218EF512F00AE444E /* JAMSVGParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3531E26401B00229F51 /* JAMStyledBezierPathFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B2E18EF512F00AE444E /* JAMStyledBezierPathFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3541E26401B00229F51 /* JAMSVGGradientParts.h in Headers */ = {isa = PBXBuildFile; fileRef = 638E660518F39529007A2EAA /* JAMSVGGradientParts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3551E26401C00229F51 /* JAMSVGImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3018EF512F00AE444E /* JAMSVGImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3561E26401C00229F51 /* UIImage+SVG.h in Headers */ = {isa = PBXBuildFile; fileRef = 630A5D2E1A637DA90051D2D5 /* UIImage+SVG.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3571E26401C00229F51 /* JAMSVGImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3818EF67A300AE444E /* JAMSVGImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3581E26401C00229F51 /* JAMSVGButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 632459451A461EB200C64553 /* JAMSVGButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C3591E26401C00229F51 /* JAMStyledBezierPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B2C18EF512F00AE444E /* JAMStyledBezierPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C35A1E26401C00229F51 /* JAMSVGParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B3218EF512F00AE444E /* JAMSVGParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C35B1E26401C00229F51 /* JAMStyledBezierPathFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A36B2E18EF512F00AE444E /* JAMStyledBezierPathFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C35C1E26401C00229F51 /* JAMSVGGradientParts.h in Headers */ = {isa = PBXBuildFile; fileRef = 638E660518F39529007A2EAA /* JAMSVGGradientParts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C35D1E26406000229F51 /* JAMSVGUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CA8DFA1A426F870095ECF3 /* JAMSVGUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8225C35E1E26406000229F51 /* JAMSVGUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CA8DFA1A426F870095ECF3 /* JAMSVGUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB5881E019D5CE2900797A2E /* Launch.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB5881DF19D5CE2900797A2E /* Launch.xib */; };
 /* End PBXBuildFile section */
 
@@ -391,7 +409,16 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8225C34E1E26401B00229F51 /* UIImage+SVG.h in Headers */,
+				8225C34F1E26401B00229F51 /* JAMSVGImageView.h in Headers */,
+				8225C3511E26401B00229F51 /* JAMStyledBezierPath.h in Headers */,
+				8225C34D1E26401B00229F51 /* JAMSVGImage.h in Headers */,
+				8225C3521E26401B00229F51 /* JAMSVGParser.h in Headers */,
+				8225C3531E26401B00229F51 /* JAMStyledBezierPathFactory.h in Headers */,
+				8225C3501E26401B00229F51 /* JAMSVGButton.h in Headers */,
+				8225C3541E26401B00229F51 /* JAMSVGGradientParts.h in Headers */,
 				8225C33B1E263EFD00229F51 /* JAMSVGImage-Umbrella.h in Headers */,
+				8225C35D1E26406000229F51 /* JAMSVGUtilities.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -399,7 +426,16 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8225C3561E26401C00229F51 /* UIImage+SVG.h in Headers */,
+				8225C3571E26401C00229F51 /* JAMSVGImageView.h in Headers */,
+				8225C3591E26401C00229F51 /* JAMStyledBezierPath.h in Headers */,
+				8225C3551E26401C00229F51 /* JAMSVGImage.h in Headers */,
+				8225C35A1E26401C00229F51 /* JAMSVGParser.h in Headers */,
+				8225C35B1E26401C00229F51 /* JAMStyledBezierPathFactory.h in Headers */,
+				8225C3581E26401C00229F51 /* JAMSVGButton.h in Headers */,
+				8225C35C1E26401C00229F51 /* JAMSVGGradientParts.h in Headers */,
 				8225C33C1E263EFE00229F51 /* JAMSVGImage-Umbrella.h in Headers */,
+				8225C35E1E26406000229F51 /* JAMSVGUtilities.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JAMSVGImage.xcodeproj/xcshareddata/xcschemes/JAMSVGImage iOS.xcscheme
+++ b/JAMSVGImage.xcodeproj/xcshareddata/xcschemes/JAMSVGImage iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8225C2FE1E26391C00229F51"
+               BuildableName = "JAMSVGImage.framework"
+               BlueprintName = "JAMSVGImage-iOS"
+               ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8225C2FE1E26391C00229F51"
+            BuildableName = "JAMSVGImage.framework"
+            BlueprintName = "JAMSVGImage-iOS"
+            ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8225C2FE1E26391C00229F51"
+            BuildableName = "JAMSVGImage.framework"
+            BlueprintName = "JAMSVGImage-iOS"
+            ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JAMSVGImage.xcodeproj/xcshareddata/xcschemes/JAMSVGImage tvOS.xcscheme
+++ b/JAMSVGImage.xcodeproj/xcshareddata/xcschemes/JAMSVGImage tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8225C3101E26392800229F51"
+               BuildableName = "JAMSVGImage.framework"
+               BlueprintName = "JAMSVGImage-tvOS"
+               ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8225C3101E26392800229F51"
+            BuildableName = "JAMSVGImage.framework"
+            BlueprintName = "JAMSVGImage-tvOS"
+            ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8225C3101E26392800229F51"
+            BuildableName = "JAMSVGImage.framework"
+            BlueprintName = "JAMSVGImage-tvOS"
+            ReferencedContainer = "container:JAMSVGImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ __Convenience__: there's no need to generate @2x and @3x versions of your art as
 
 __File Size__: SVG and SVGZ (gzipped SVG) are typically a fraction of the file size of a set of PNG or JPG art assets.
 
+Installation
+-----
+
+If you are using Swift in your project, the recommended way of installing this library is via [Carthage](https://github.com/Carthage/Carthage). [Cocoapods](https://github.com/CocoaPods/CocoaPods) is supported, too. You can of course also just include this framework manually into your project by downloading it or by using git submodules.
+
+### Carthage
+
+Add the following line to your `Cartfile`:
+
+``` Swift
+github "jmenter/JAMSVGImage" ~> 1.7
+```
+
+Now run `carthage update`. Then drag & drop the JAMSVGImage.framework in the Carthage/Build folder to your project. Now you can `import JAMSVGImage` in each class you want to use its features. Refer to the [Carthage README](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for detailed / updated instructions.
+
+### CocoaPods
+
+Add the line `pod 'JAMSVGImage'` to your target in your `Podfile` and make sure to include `use_frameworks!`
+at the top. The result might look similar to this:
+
+``` Ruby
+platform :ios, '8.0'
+use_frameworks!
+
+target 'MyAppTarget' do
+    pod 'JAMSVGImage', '~> 1.7'
+end
+```
+
+Now close your project and run `pod install` from the command line. Then open the `.xcworkspace` from within your project folder.
+Build your project once (with `Cmd+B`) to update the frameworks known to Xcode. Now you can `import JAMSVGImage` in each class you want to use its features.
+Refer to [CocoaPods.org](https://cocoapods.org) for detailed / updates instructions.
+
+
 Usage
 -----
 
@@ -42,7 +76,7 @@ Third, you can create a JAMSVGImage instance and use the drawInCurrentContext me
 You can also call [tiger image] or .CGImage to get a raster UIImage or CGImageRef and use that anywhere you would use a UIImage or CGImageRef. You can set the scale before getting the image if you need it bigger or smaller, or you can pass in a rect to have the SVG rendered in that rect at the proper scale for your device (whether it's a @1x, @2x, or @3x screen):
 
     [self.button setBackgroundImage:[[JAMSVGImage imageNamed:@"fancyButton"] imageAtSize:self.button.bounds.size] forState:UIControlStateNormal];
-    
+
 Last, there is a JAMSVGButton subclass of UIButton that allows setting the four button states to SVG files via Interface Builder.
 
 ![JAMSVGButton Example](https://raw.githubusercontent.com/jmenter/JAMSVGImage/develop/svgButtonExample.png)


### PR DESCRIPTION
This is a follow-up on #32 which you ( @jmenter ) didn't have time to review as it contained too many changes. This is a new approach to add Carthage support, this time with as minimal changes as possible (without the project restructuring I had done in #32) so **you can review much more quickly**.

This also adds an option to **opt-out of the basic caching support** added via #17 – the problem with forced caching is that it is sometimes done in the application domain already and caching them in JAMSVGImage makes them available twice leading to twice the memory size than needed.